### PR TITLE
BeanBagException now prints user friendly msg

### DIFF
--- a/beanbag/__init__.py
+++ b/beanbag/__init__.py
@@ -345,10 +345,14 @@ class BeanBagException(Exception):
         self.request = request
 
     def __repr__(self):
-        return "%s(%s,...)" % (self.__class__.__name__, self.msg)
+        return "%s(%s,%s,%s)" % (self.__class__.__name__, self.msg,
+          self.response, self.request)
 
     def __str__(self):
-        return self.msg
+        msg = self.msg
+        if self.response and hasattr(self.response, "context"):
+          msg = "%s - response: %s" % (self.msg, self.response.content)
+        return msg
 
 
 class KerbAuth(requests.auth.AuthBase):


### PR DESCRIPTION
- Put response.context only if it really exists -> leads to another exception
- fix repr for BeanBagException so eval(repr(BeanBagException)) actaully works
